### PR TITLE
Fix: Correct TypeScript compilation errors

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import './Modal.css';
 
 interface ModalProps {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
+import { createContext, useState, useContext, type ReactNode, useEffect } from 'react';
 import axios from 'axios';
 
 interface AuthContextType {


### PR DESCRIPTION
This commit fixes two types of TypeScript errors that appeared after a recent merge:

1.  `TS1484: 'ReactNode' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.`
    - This was fixed by changing the import of `ReactNode` to `import type { ReactNode } from 'react'` in `src/components/Modal/Modal.tsx` and `src/context/AuthContext.tsx`.

2.  `TS6133: 'React' is declared but its value is never read.`
    - This was fixed by removing the unused `React` import from `src/context/AuthContext.tsx`.